### PR TITLE
{WIP} Part 3 Of Async Compaction : Ensure Compaction CLient Handler handles metrics and compaction-commit  in a consistent way for both inline and non-inline compactions

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/CommitUtils.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/CommitUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie;
+
+import com.codahale.metrics.Timer;
+import com.uber.hoodie.common.model.HoodieCommitMetadata;
+import com.uber.hoodie.common.model.HoodieRecordPayload;
+import com.uber.hoodie.common.model.HoodieWriteStat;
+import com.uber.hoodie.metrics.HoodieMetrics;
+import com.uber.hoodie.table.HoodieTable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.PairFunction;
+import scala.Tuple2;
+
+/**
+ * Utils class providing common functions used in commit
+ */
+class CommitUtils {
+
+  private static Logger logger = LogManager.getLogger(CommitUtils.class);
+
+  /**
+   * Generate partition level write stats
+   *
+   * @param metadata      Metadata to write
+   * @param writeStatuses Write Statuses
+   * @param extraMetadata Additional Metadata to write
+   * @return Partition Level stats
+   */
+  protected static List<Tuple2<String, HoodieWriteStat>> generateWriteStats(HoodieCommitMetadata metadata,
+      JavaRDD<WriteStatus> writeStatuses,
+      Optional<Map<String, String>> extraMetadata) {
+    List<Tuple2<String, HoodieWriteStat>> stats = writeStatuses.mapToPair(
+        (PairFunction<WriteStatus, String, HoodieWriteStat>) writeStatus -> new Tuple2<>(
+            writeStatus.getPartitionPath(), writeStatus.getStat())).collect();
+    for (Tuple2<String, HoodieWriteStat> stat : stats) {
+      metadata.addWriteStat(stat._1(), stat._2());
+    }
+
+    // add in extra metadata
+    if (extraMetadata.isPresent()) {
+      extraMetadata.get().forEach((k, v) -> metadata.addMetadata(k, v));
+    }
+    return stats;
+  }
+
+  /**
+   * Finalize Write on table and update metrics
+   *
+   * @param jsc     Spark Context
+   * @param table   Hoodie Table
+   * @param metrics Metrics
+   * @param stats   Partition Level stats
+   * @param <T>     Record Payload Type
+   */
+  protected static <T extends HoodieRecordPayload> void finalizeWrite(JavaSparkContext jsc,
+      HoodieTable<T> table, HoodieMetrics metrics, List<Tuple2<String, HoodieWriteStat>> stats) {
+    // Finalize write
+    final Timer.Context finalizeCtx = metrics.getFinalizeCtx();
+    final Optional<Integer> result = table.finalizeWrite(jsc, stats);
+    if (finalizeCtx != null && result.isPresent()) {
+      Optional<Long> durationInMs = Optional.of(metrics.getDurationInMs(finalizeCtx.stop()));
+      durationInMs.ifPresent(duration -> {
+        logger.info("Finalize write elapsed time (milliseconds): " + duration);
+        metrics.updateFinalizeWriteMetrics(duration, result.get());
+      });
+    }
+  }
+}

--- a/hoodie-client/src/main/java/com/uber/hoodie/CompactionClientHandler.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/CompactionClientHandler.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie;
+
+import com.codahale.metrics.Timer;
+import com.uber.hoodie.common.model.HoodieCommitMetadata;
+import com.uber.hoodie.common.model.HoodieRecordPayload;
+import com.uber.hoodie.common.model.HoodieWriteStat;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.HoodieTimeline;
+import com.uber.hoodie.common.table.timeline.HoodieActiveTimeline;
+import com.uber.hoodie.common.table.timeline.HoodieInstant;
+import com.uber.hoodie.common.util.FSUtils;
+import com.uber.hoodie.config.HoodieWriteConfig;
+import com.uber.hoodie.exception.HoodieCommitException;
+import com.uber.hoodie.exception.HoodieCompactionException;
+import com.uber.hoodie.metrics.HoodieMetrics;
+import com.uber.hoodie.table.HoodieTable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+
+/**
+ * Non-Public API : Compaction Handler taking care of both scheduling and running compactions
+ */
+class CompactionClientHandler<T extends HoodieRecordPayload> implements Serializable {
+
+  private static Logger logger = LogManager.getLogger(CompactionClientHandler.class);
+
+  private final transient FileSystem fs;
+  private final transient JavaSparkContext jsc;
+  private final HoodieWriteConfig config;
+  private final transient HoodieMetrics metrics;
+
+  protected CompactionClientHandler(JavaSparkContext jsc, HoodieWriteConfig clientConfig,
+      HoodieMetrics metrics) {
+    this.fs = FSUtils.getFs(clientConfig.getBasePath(), jsc.hadoopConfiguration());
+    this.jsc = jsc;
+    this.config = clientConfig;
+    this.metrics = metrics;
+  }
+
+  /**
+   * Provides a new commit time for a compaction (commit) operation
+   */
+  protected String startCompaction() {
+    String commitTime = HoodieActiveTimeline.createNewCommitTime();
+    logger.info("Generate a new commit time " + commitTime);
+    startCompactionWithTime(commitTime);
+    return commitTime;
+  }
+
+  /**
+   * Since MOR tableType default to {@link HoodieTimeline#DELTA_COMMIT_ACTION}, we need to
+   * explicitly set to {@link HoodieTimeline#COMMIT_ACTION} for compaction
+   *
+   * @param commitTime Compaction Commit Time
+   */
+  protected void startCompactionWithTime(String commitTime) {
+    HoodieTable<T> table = HoodieTable.getHoodieTable(
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+    HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
+    String commitActionType = HoodieTimeline.COMMIT_ACTION;
+    activeTimeline.createInflight(new HoodieInstant(true, commitActionType, commitTime));
+  }
+
+  /**
+   * Performs a compaction operation on a dataset. WARNING: Compaction operation cannot be executed
+   * asynchronously. Please always use this serially before or after an insert/upsert action.
+   */
+  /**
+   * Performs a compaction operation on a dataset. WARNING: Compaction operation cannot be executed
+   * asynchronously. Please always use this serially before or after an insert/upsert action.
+   *
+   * @param table      Hoodie Table
+   * @param commitTime Compacton Instant time
+   * @return WriteStatus RDD of compaction
+   */
+  protected JavaRDD<WriteStatus> compact(HoodieTable<T> table, String commitTime) throws IOException {
+    // TODO : Fix table.getActionType for MOR table type to return different actions based on delta or compaction
+    JavaRDD<WriteStatus> statuses = table.compact(jsc, commitTime);
+    // Trigger the insert and collect statuses
+    return statuses.persist(config.getWriteStatusStorageLevel());
+  }
+
+  /**
+   * Performs a compaction operation on a dataset. WARNING: Compaction operation cannot be executed
+   * asynchronously. Please always use this serially before or after an insert/upsert action.
+   *
+   * @param compactionCommitTime Compaction Commit Time
+   */
+  private void forceCompact(String compactionCommitTime) throws IOException {
+    // Create a Hoodie table which encapsulated the commits and files visible
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(),
+        config.getBasePath(), true);
+    HoodieTable<T> table = HoodieTable.getHoodieTable(metaClient, config);
+    // TODO : Fix table.getActionType for MOR table type to return different actions based on delta or compaction and
+    // then use getTableAndInitCtx
+    Timer.Context writeTimerContext = metrics.getCommitCtx();
+    JavaRDD<WriteStatus> compactedStatuses = table.compact(jsc, compactionCommitTime);
+    if (!compactedStatuses.isEmpty()) {
+      HoodieCommitMetadata metadata = commitForceCompaction(compactedStatuses, metaClient, compactionCommitTime);
+      long durationInMs = metrics.getDurationInMs(writeTimerContext.stop());
+      try {
+        metrics
+            .updateCommitMetrics(HoodieActiveTimeline.COMMIT_FORMATTER.parse(compactionCommitTime).getTime(),
+                durationInMs, metadata, HoodieActiveTimeline.COMMIT_ACTION);
+      } catch (ParseException e) {
+        throw new HoodieCommitException(
+            "Commit time is not of valid format.Failed to commit " + config.getBasePath()
+                + " at time " + compactionCommitTime, e);
+      }
+      logger.info("Compacted successfully on commit " + compactionCommitTime);
+    } else {
+      writeTimerContext.close();
+      logger.info("Compaction did not run for commit " + compactionCommitTime);
+    }
+  }
+
+  /**
+   * Performs a compaction operation on a dataset. WARNING: Compaction operation cannot be executed
+   * asynchronously. Please always use this serially before or after an insert/upsert action.
+   */
+  protected String forceCompact() throws IOException {
+    String compactionCommitTime = startCompaction();
+    forceCompact(compactionCommitTime);
+    return compactionCommitTime;
+  }
+
+  private HoodieCommitMetadata commitForceCompaction(JavaRDD<WriteStatus> writeStatuses,
+      HoodieTableMetaClient metaClient, String compactionCommitTime) {
+    List<HoodieWriteStat> updateStatusMap = writeStatuses.map(writeStatus -> writeStatus.getStat())
+        .collect();
+
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata(true);
+    for (HoodieWriteStat stat : updateStatusMap) {
+      metadata.addWriteStat(stat.getPartitionPath(), stat);
+    }
+
+    logger.info("Compaction finished with result " + metadata);
+
+    logger.info("Committing Compaction " + compactionCommitTime);
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+
+    try {
+      activeTimeline.saveAsComplete(
+          new HoodieInstant(true, HoodieTimeline.COMMIT_ACTION, compactionCommitTime),
+          Optional.of(metadata.toJsonString().getBytes(StandardCharsets.UTF_8)));
+    } catch (IOException e) {
+      throw new HoodieCompactionException(
+          "Failed to commit " + metaClient.getBasePath() + " at time " + compactionCommitTime, e);
+    }
+    return metadata;
+  }
+}

--- a/hoodie-client/src/main/java/com/uber/hoodie/RollbackHandler.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/RollbackHandler.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie;
+
+import com.codahale.metrics.Timer;
+import com.uber.hoodie.avro.model.HoodieRollbackMetadata;
+import com.uber.hoodie.common.HoodieRollbackStat;
+import com.uber.hoodie.common.model.HoodieRecordPayload;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.HoodieTimeline;
+import com.uber.hoodie.common.table.timeline.HoodieActiveTimeline;
+import com.uber.hoodie.common.table.timeline.HoodieInstant;
+import com.uber.hoodie.common.table.timeline.HoodieInstant.State;
+import com.uber.hoodie.common.util.AvroUtils;
+import com.uber.hoodie.common.util.FSUtils;
+import com.uber.hoodie.config.HoodieWriteConfig;
+import com.uber.hoodie.exception.HoodieRollbackException;
+import com.uber.hoodie.index.HoodieIndex;
+import com.uber.hoodie.metrics.HoodieMetrics;
+import com.uber.hoodie.table.HoodieTable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaSparkContext;
+
+/**
+ * Non-Public class performing Rollback of instants. Used by write and compaction use-cases
+ */
+class RollbackHandler<T extends HoodieRecordPayload> implements Serializable {
+
+  private static Logger logger = LogManager.getLogger(RollbackHandler.class);
+
+  private final transient FileSystem fs;
+  private final transient JavaSparkContext jsc;
+  private final HoodieWriteConfig config;
+  private final transient HoodieIndex<T> index;
+  private final transient HoodieMetrics metrics;
+
+  protected RollbackHandler(JavaSparkContext jsc, HoodieIndex<T> index, HoodieWriteConfig clientConfig,
+      HoodieMetrics metrics) {
+    this.fs = FSUtils.getFs(clientConfig.getBasePath(), jsc.hadoopConfiguration());
+    this.jsc = jsc;
+    this.index = index;
+    this.config = clientConfig;
+    this.metrics = metrics;
+  }
+
+  /**
+   * Roll back commits
+   * @param commits
+   */
+  public void rollback(List<String> commits) {
+    if (commits.isEmpty()) {
+      logger.info("List of commits to rollback is empty");
+      return;
+    }
+
+    final Timer.Context context = metrics.getRollbackCtx();
+    String startRollbackTime = HoodieActiveTimeline.COMMIT_FORMATTER.format(new Date());
+
+    // Create a Hoodie table which encapsulated the commits and files visible
+    HoodieTable<T> table = HoodieTable.getHoodieTable(
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+    HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
+    HoodieTimeline inflightTimeline = table.getInflightCommitTimeline();
+    HoodieTimeline commitTimeline = table.getCompletedCommitTimeline();
+
+    // Check if any of the commits is a savepoint - do not allow rollback on those commits
+    List<String> savepoints = table.getCompletedSavepointTimeline().getInstants()
+        .map(HoodieInstant::getTimestamp).collect(Collectors.toList());
+    commits.forEach(s -> {
+      if (savepoints.contains(s)) {
+        throw new HoodieRollbackException(
+            "Could not rollback a savepointed commit. Delete savepoint first before rolling back"
+                + s);
+      }
+    });
+
+    try {
+      if (commitTimeline.empty() && inflightTimeline.empty()) {
+        // nothing to rollback
+        logger.info("No commits to rollback " + commits);
+      }
+
+      // Make sure only the last n commits are being rolled back
+      // If there is a commit in-between or after that is not rolled back, then abort
+      String lastCommit = commits.get(commits.size() - 1);
+      if (!commitTimeline.empty() && !commitTimeline
+          .findInstantsAfter(lastCommit, Integer.MAX_VALUE).empty()) {
+        throw new HoodieRollbackException(
+            "Found commits after time :" + lastCommit + ", please rollback greater commits first");
+      }
+
+      List<String> inflights = inflightTimeline.getInstants().map(HoodieInstant::getTimestamp)
+          .collect(Collectors.toList());
+      if (!inflights.isEmpty() && inflights.indexOf(lastCommit) != inflights.size() - 1) {
+        throw new HoodieRollbackException("Found in-flight commits after time :" + lastCommit
+            + ", please rollback greater commits first");
+      }
+
+      List<HoodieRollbackStat> stats = table.rollback(jsc, commits);
+
+      // cleanup index entries
+      commits.stream().forEach(s -> {
+        if (!index.rollbackCommit(s)) {
+          throw new HoodieRollbackException("Rollback index changes failed, for time :" + s);
+        }
+      });
+      logger.info("Index rolled back for commits " + commits);
+
+      Optional<Long> durationInMs = Optional.empty();
+      if (context != null) {
+        durationInMs = Optional.of(metrics.getDurationInMs(context.stop()));
+        Long numFilesDeleted = stats.stream().mapToLong(stat -> stat.getSuccessDeleteFiles().size())
+            .sum();
+        metrics.updateRollbackMetrics(durationInMs.get(), numFilesDeleted);
+      }
+      HoodieRollbackMetadata rollbackMetadata = AvroUtils
+          .convertRollbackMetadata(startRollbackTime, durationInMs, commits, stats);
+      table.getActiveTimeline().saveAsComplete(
+          new HoodieInstant(State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, startRollbackTime),
+          AvroUtils.serializeRollbackMetadata(rollbackMetadata));
+      logger.info("Commits " + commits + " rollback is complete");
+
+      if (!table.getActiveTimeline().getCleanerTimeline().empty()) {
+        logger.info("Cleaning up older rollback meta files");
+        // Cleanup of older cleaner meta files
+        // TODO - make the commit archival generic and archive rollback metadata
+        FSUtils.deleteOlderRollbackMetaFiles(fs, table.getMetaClient().getMetaPath(),
+            table.getActiveTimeline().getRollbackTimeline().getInstants());
+      }
+    } catch (IOException e) {
+      throw new HoodieRollbackException(
+          "Failed to rollback " + config.getBasePath() + " commits " + commits, e);
+    }
+  }
+}

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
@@ -696,7 +696,7 @@ public class TestMergeOnReadTable {
     // Do a compaction
     String commitTime = writeClient.startCompaction();
     statuses = writeClient.compact(commitTime);
-    writeClient.commitCompaction(commitTime, statuses);
+    writeClient.commitCompaction(commitTime, statuses, Optional.empty());
     // total time taken for scanning log files should be greater than 0
     long timeTakenForScanner = statuses.map(writeStatus -> writeStatus.getStat().getRuntimeStats().getTotalScanTime())
         .reduce((a,b) -> a + b).longValue();


### PR DESCRIPTION
 HoodieWriteClient's compaction implementation are cleaned up to make sure both inline (compaction during ingestion) and non-inline (compaction-only) versions with auto-commit on/off are able to reuse code. 

Depends on https://github.com/bvaradar/hudi/pull/1

Changes to HoodieWriteClient API will follow this diff