### PR TITLE
Part 4 of Async Compaction : Ensure Compaction workload is stored in write-once meta-data files separate from timeline files

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieCompactionInstantWithPlan.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieCompactionInstantWithPlan.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.uber.hoodie.io.compact;
+
+import com.uber.hoodie.avro.model.HoodieCompactionPlan;
+
+/**
+ * Contains Hoodie Compaction instant along with workload
+ */
+public class HoodieCompactionInstantWithPlan {
+
+  private final String compactionInstantTime;
+  private final HoodieCompactionPlan compactionPlan;
+
+  public HoodieCompactionInstantWithPlan(String compactionInstantTime,
+      HoodieCompactionPlan compactionPlan) {
+    this.compactionInstantTime = compactionInstantTime;
+    this.compactionPlan = compactionPlan;
+  }
+
+  public String getCompactionInstantTime() {
+    return compactionInstantTime;
+  }
+
+  public HoodieCompactionPlan getCompactionPlan() {
+    return compactionPlan;
+  }
+}

--- a/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieTestDataGenerator.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieTestDataGenerator.java
@@ -16,6 +16,7 @@
 
 package com.uber.hoodie.common;
 
+import com.uber.hoodie.avro.model.HoodieCompactionPlan;
 import com.uber.hoodie.common.model.HoodieCommitMetadata;
 import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.model.HoodiePartitionMetadata;
@@ -23,6 +24,8 @@ import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieTestUtils;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.table.HoodieTimeline;
+import com.uber.hoodie.common.table.timeline.HoodieInstant;
+import com.uber.hoodie.common.util.AvroUtils;
 import com.uber.hoodie.common.util.FSUtils;
 import com.uber.hoodie.common.util.HoodieAvroUtils;
 import java.io.IOException;
@@ -130,6 +133,21 @@ public class HoodieTestDataGenerator {
     try {
       // Write empty commit metadata
       os.writeBytes(new String(commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8)));
+    } finally {
+      os.close();
+    }
+  }
+
+  public static void createCompactionAuxiliaryMetadata(String basePath, HoodieInstant instant,
+      Configuration configuration) throws IOException {
+    Path commitFile = new Path(
+        basePath + "/" + HoodieTableMetaClient.AUXILIARYFOLDER_NAME + "/" + instant.getFileName());
+    FileSystem fs = FSUtils.getFs(basePath, configuration);
+    FSDataOutputStream os = fs.create(commitFile, true);
+    HoodieCompactionPlan workload = new HoodieCompactionPlan();
+    try {
+      // Write empty commit metadata
+      os.writeBytes(new String(AvroUtils.serializeCompactionPlan(workload).get(), StandardCharsets.UTF_8));
     } finally {
       os.close();
     }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieInstant.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieInstant.java
@@ -84,6 +84,10 @@ public class HoodieInstant implements Serializable {
     this.timestamp = timestamp;
   }
 
+  public boolean isCompleted() {
+    return state == State.COMPLETED;
+  }
+
   public boolean isInflight() {
     return state == State.INFLIGHT;
   }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/AvroUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/AvroUtils.java
@@ -143,7 +143,7 @@ public class AvroUtils {
         partitionMetadataBuilder.build());
   }
 
-  public static Optional<byte[]> serializeCompactionWorkload(HoodieCompactionPlan compactionWorkload)
+  public static Optional<byte[]> serializeCompactionPlan(HoodieCompactionPlan compactionWorkload)
       throws IOException {
     return serializeAvroMetadata(compactionWorkload, HoodieCompactionPlan.class);
   }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/CompactionUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/CompactionUtils.java
@@ -21,6 +21,7 @@ import com.uber.hoodie.avro.model.HoodieCompactionPlan;
 import com.uber.hoodie.common.model.CompactionOperation;
 import com.uber.hoodie.common.model.FileSlice;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.HoodieTimeline;
 import com.uber.hoodie.common.table.timeline.HoodieInstant;
 import com.uber.hoodie.exception.HoodieException;
 import java.io.IOException;
@@ -114,7 +115,8 @@ public class CompactionUtils {
     return pendingCompactionInstants.stream().map(instant -> {
       try {
         HoodieCompactionPlan compactionPlan = AvroUtils.deserializeCompactionPlan(
-            metaClient.getActiveTimeline().getInstantDetails(instant).get());
+            metaClient.getActiveTimeline().getInstantAuxiliaryDetails(
+                HoodieTimeline.getCompactionRequestedInstant(instant.getTimestamp())).get());
         return Pair.of(instant, compactionPlan);
       } catch (IOException e) {
         throw new HoodieException(e);

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/table/view/HoodieTableFileSystemViewTest.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/table/view/HoodieTableFileSystemViewTest.java
@@ -252,10 +252,12 @@ public class HoodieTableFileSystemViewTest {
       // Create a Data-file but this should be skipped by view
       new File(basePath + "/" + partitionPath + "/" + compactDataFileName).createNewFile();
       compactionInstant = new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, compactionRequestedTime);
-      commitTimeline.saveToInflight(compactionInstant, AvroUtils.serializeCompactionWorkload(compactionPlan));
+      HoodieInstant requested = HoodieTimeline.getCompactionRequestedInstant(compactionInstant.getTimestamp());
+      commitTimeline.saveToCompactionRequested(requested, AvroUtils.serializeCompactionPlan(compactionPlan));
+      commitTimeline.transitionCompactionRequestedToInflight(requested);
     } else {
       compactionInstant = new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, compactionRequestedTime);
-      commitTimeline.saveToRequested(compactionInstant, AvroUtils.serializeCompactionWorkload(compactionPlan));
+      commitTimeline.saveToCompactionRequested(compactionInstant, AvroUtils.serializeCompactionPlan(compactionPlan));
     }
 
     // Fake delta-ingestion after compaction-requested

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/util/TestCompactionUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/util/TestCompactionUtils.java
@@ -241,13 +241,17 @@ public class TestCompactionUtils {
   }
 
   private void scheduleCompaction(String instantTime, HoodieCompactionPlan compactionPlan) throws IOException {
-    metaClient.getActiveTimeline().saveToRequested(new HoodieInstant(State.REQUESTED, COMPACTION_ACTION, instantTime),
-        AvroUtils.serializeCompactionWorkload(compactionPlan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(
+        new HoodieInstant(State.REQUESTED, COMPACTION_ACTION, instantTime),
+        AvroUtils.serializeCompactionPlan(compactionPlan));
   }
 
   private void scheduleInflightCompaction(String instantTime, HoodieCompactionPlan compactionPlan) throws IOException {
-    metaClient.getActiveTimeline().saveToInflight(new HoodieInstant(State.INFLIGHT, COMPACTION_ACTION, instantTime),
-        AvroUtils.serializeCompactionWorkload(compactionPlan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(
+        new HoodieInstant(State.REQUESTED, COMPACTION_ACTION, instantTime),
+        AvroUtils.serializeCompactionPlan(compactionPlan));
+    metaClient.getActiveTimeline().transitionCompactionRequestedToInflight(
+        new HoodieInstant(State.REQUESTED, COMPACTION_ACTION, instantTime));
   }
 
   private HoodieCompactionPlan createCompactionPlan(String instantId, int numFileIds) {


### PR DESCRIPTION
This avoids concurrency issues when compactor(s) and ingestion are running in parallel.
NOTE: In the Next PR -> Safety concern regarding Cleaner retaining all meta-data and file-slices for pending compactions will be addressed