### PR TITLE
Fix to allow cross file system bootstrap

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapCommitActionExecutor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapCommitActionExecutor.java
@@ -102,6 +102,7 @@ public class BootstrapCommitActionExecutor<T extends HoodieRecordPayload<T>>
 
   private static final Logger LOG = LogManager.getLogger(BootstrapCommitActionExecutor.class);
   protected String bootstrapSchema = null;
+  private transient FileSystem bootstrapSourceFileSystem;
 
   public BootstrapCommitActionExecutor(JavaSparkContext jsc, HoodieWriteConfig config, HoodieTable<?> table,
       Option<Map<String, String>> extraMetadata) {
@@ -110,6 +111,7 @@ public class BootstrapCommitActionExecutor<T extends HoodieRecordPayload<T>>
         .withBulkInsertParallelism(config.getBootstrapParallelism())
         .build(), table, HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS, WriteOperationType.BOOTSTRAP,
         extraMetadata);
+    bootstrapSourceFileSystem = FSUtils.getFs(config.getBootstrapSourceBasePath(), hadoopConf);
   }
 
   private void checkArguments() {
@@ -292,9 +294,8 @@ public class BootstrapCommitActionExecutor<T extends HoodieRecordPayload<T>>
       HoodieTableMetaClient metaClient) throws IOException {
     //TODO: Added HoodieFilter for manually testing bootstrap from source hudi table. Needs to be reverted.
     final PathFilter hoodieFilter = new HoodieROTablePathFilter();
-    FileSystem fs = new Path(config.getBootstrapSourceBasePath()).getFileSystem(jsc.hadoopConfiguration());
     List<Pair<String, List<HoodieFileStatus>>> folders =
-        FSUtils.getAllLeafFoldersWithFiles(fs,
+        FSUtils.getAllLeafFoldersWithFiles(bootstrapSourceFileSystem,
             config.getBootstrapSourceBasePath(), new PathFilter() {
               @Override
               public boolean accept(Path path) {


### PR DESCRIPTION
This PR is to fix bootstrap so that source and target file systems can be different. It also helps fix bootstrap from one S3 bucket to another S3 bucket.