### PR TITLE
Fix bootstrap indexes being created at incorrect path

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/HFileBasedBootstrapIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/HFileBasedBootstrapIndex.java
@@ -111,13 +111,13 @@ public class HFileBasedBootstrapIndex extends BootstrapIndex {
   }
 
   private static Path getIndexByPartitionPath(HoodieTableMetaClient metaClient) {
-    return new Path(metaClient.getBootstrapIndexByPartitionFolderName(),
+    return new Path(metaClient.getBootstrapIndexByPartitionFolderPath(),
         FSUtils.makeBootstrapIndexFileName(HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS, BOOTSTRAP_INDEX_FILE_ID,
             BOOTSTRAP_INDEX_FILE_TYPE));
   }
 
   private static Path getIndexByFileIdPath(HoodieTableMetaClient metaClient) {
-    return new Path(metaClient.getBootstrapIndexByFileIdFolderNameFolderName(),
+    return new Path(metaClient.getBootstrapIndexByFileIdFolderNameFolderPath(),
         FSUtils.makeBootstrapIndexFileName(HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS, BOOTSTRAP_INDEX_FILE_ID,
             BOOTSTRAP_INDEX_FILE_TYPE));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -73,10 +73,10 @@ public class HoodieTableMetaClient implements Serializable {
   public static final String METAFOLDER_NAME = ".hoodie";
   public static final String TEMPFOLDER_NAME = METAFOLDER_NAME + File.separator + ".temp";
   public static final String AUXILIARYFOLDER_NAME = METAFOLDER_NAME + File.separator + ".aux";
-  public static final String BOOTSTRAP_INDEX_ROOT_FOLDER_NAME = AUXILIARYFOLDER_NAME + File.separator + ".bootstrap";
-  public static final String BOOTSTRAP_INDEX_BY_PARTITION_FOLDER_NAME = BOOTSTRAP_INDEX_ROOT_FOLDER_NAME + File.separator
-      + ".partitions";
-  public static final String BOOTSTRAP_INDEX_BY_FILE_ID_FOLDER_NAME = BOOTSTRAP_INDEX_ROOT_FOLDER_NAME + File.separator
+  public static final String BOOTSTRAP_INDEX_ROOT_FOLDER_PATH = AUXILIARYFOLDER_NAME + File.separator + ".bootstrap";
+  public static final String BOOTSTRAP_INDEX_BY_PARTITION_FOLDER_PATH = BOOTSTRAP_INDEX_ROOT_FOLDER_PATH
+      + File.separator + ".partitions";
+  public static final String BOOTSTRAP_INDEX_BY_FILE_ID_FOLDER_PATH = BOOTSTRAP_INDEX_ROOT_FOLDER_PATH + File.separator
       + ".fileids";
 
   public static final String MARKER_EXTN = ".marker";
@@ -216,15 +216,15 @@ public class HoodieTableMetaClient implements Serializable {
   /**
    * @return Bootstrap Index By Partition Folder
    */
-  public String getBootstrapIndexByPartitionFolderName() {
-    return getMetaAuxiliaryPath() + File.separator + BOOTSTRAP_INDEX_BY_PARTITION_FOLDER_NAME;
+  public String getBootstrapIndexByPartitionFolderPath() {
+    return basePath + File.separator + BOOTSTRAP_INDEX_BY_PARTITION_FOLDER_PATH;
   }
 
   /**
    * @return Bootstrap Index By Hudi File Id Folder
    */
-  public String getBootstrapIndexByFileIdFolderNameFolderName() {
-    return getMetaAuxiliaryPath() + File.separator + BOOTSTRAP_INDEX_BY_FILE_ID_FOLDER_NAME;
+  public String getBootstrapIndexByFileIdFolderNameFolderPath() {
+    return basePath + File.separator + BOOTSTRAP_INDEX_BY_FILE_ID_FOLDER_PATH;
   }
 
   /**
@@ -409,7 +409,7 @@ public class HoodieTableMetaClient implements Serializable {
 
     // Create bootstrap index by partition folder if it does not exist
     final Path bootstrap_index_folder_by_partition =
-        new Path(basePath, HoodieTableMetaClient.BOOTSTRAP_INDEX_BY_PARTITION_FOLDER_NAME);
+        new Path(basePath, HoodieTableMetaClient.BOOTSTRAP_INDEX_BY_PARTITION_FOLDER_PATH);
     if (!fs.exists(bootstrap_index_folder_by_partition)) {
       fs.mkdirs(bootstrap_index_folder_by_partition);
     }
@@ -417,7 +417,7 @@ public class HoodieTableMetaClient implements Serializable {
 
     // Create bootstrap index by partition folder if it does not exist
     final Path bootstrap_index_folder_by_fileids =
-        new Path(basePath, HoodieTableMetaClient.BOOTSTRAP_INDEX_BY_FILE_ID_FOLDER_NAME);
+        new Path(basePath, HoodieTableMetaClient.BOOTSTRAP_INDEX_BY_FILE_ID_FOLDER_PATH);
     if (!fs.exists(bootstrap_index_folder_by_fileids)) {
       fs.mkdirs(bootstrap_index_folder_by_fileids);
     }


### PR DESCRIPTION
This fixes the issue of bootstrap indexes being created at incorrect paths.

We would see the index at: ```.hoodie/.aux/.hoodie/.aux/.bootstrap/..``` instead of at ```/.hoodie/.aux/.bootstrap```